### PR TITLE
Update SSH secret name for operator and make customer ssh key set by zlifecycle not CRDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,6 @@ the default value http://argocd-server.argocd.svc.cluster.local.
 Check LastPass for secret values.
 TODO: Refactor ARGOCD_WEBHOOK_URL and ARGOCD_API_URL to be a config variable instead of a secret value
 
-### Auto-registration of team config repos
-`Team` resource has a `repoSecret` field which is the name of the secret which holds the SSH key for the team config repo.
-The secret should have the private SSH key stored in base64 format in the `sshPrivateKey` field.
-
 ## Vendoring
 
 We are using `go mod vendor` for our code so that all dependencies are available to the operator without relying on external sources. 

--- a/api/v1alpha1/company_types.go
+++ b/api/v1alpha1/company_types.go
@@ -22,7 +22,6 @@ import (
 type CompanyConfigRepo struct {
 	Source string `json:"source"`
 	Path   string `json:"path"`
-	RepoSecret string `json:"repoSecret"`
 }
 
 // CompanySpec defines the desired state of Company

--- a/api/v1alpha1/team_types.go
+++ b/api/v1alpha1/team_types.go
@@ -17,9 +17,8 @@ import (
 )
 
 type Repo struct {
-	Source     string `json:"source"`
-	RepoSecret string `json:"repoSecret"`
-	Path       string `json:"path"`
+	Source string `json:"source"`
+	Path   string `json:"path"`
 }
 
 // TeamSpec defines the desired state of Team

--- a/charts/zlifecycle-il-operator/crds/stable.compuzest.com_companies.yaml
+++ b/charts/zlifecycle-il-operator/crds/stable.compuzest.com_companies.yaml
@@ -44,13 +44,10 @@ spec:
                 properties:
                   path:
                     type: string
-                  repoSecret:
-                    type: string
                   source:
                     type: string
                 required:
                 - path
-                - repoSecret
                 - source
                 type: object
             required:

--- a/charts/zlifecycle-il-operator/crds/stable.compuzest.com_teams.yaml
+++ b/charts/zlifecycle-il-operator/crds/stable.compuzest.com_teams.yaml
@@ -40,13 +40,10 @@ spec:
                 properties:
                   path:
                     type: string
-                  repoSecret:
-                    type: string
                   source:
                     type: string
                 required:
                 - path
-                - repoSecret
                 - source
                 type: object
               teamName:

--- a/charts/zlifecycle-il-operator/values.yaml
+++ b/charts/zlifecycle-il-operator/values.yaml
@@ -14,7 +14,7 @@ env:
   ARGOCD_SERVER_URL: "argocd-server"
   GITHUB_ZLIFECYCLE_OWNER: CompuZest
   GITHUB_WEBHOOK_SECRET: !!!CHANGEME!!!
-  ZLIFECYCLE_MASTER_SSH: zlifecycle-ssh
+  ZLIFECYCLE_MASTER_SSH: zlifecycle-operator-ssh
 
 resources:
   limits:

--- a/controllers/company_controller.go
+++ b/controllers/company_controller.go
@@ -48,7 +48,7 @@ func (r *CompanyReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	r.Get(ctx, req.NamespacedName, company)
 
 	companyRepo := company.Spec.ConfigRepo.Source
-	repoSecret := company.Spec.ConfigRepo.RepoSecret
+	repoSecret := il.SSHKeyName()
 
 	argocdApi := argocd.NewHttpClient(r.Log, env.Config.ArgocdServerUrl)
 

--- a/controllers/team_controller.go
+++ b/controllers/team_controller.go
@@ -60,7 +60,7 @@ func (r *TeamReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	}
 
 	teamRepo := team.Spec.ConfigRepo.Source
-	repoSecret := team.Spec.ConfigRepo.RepoSecret
+	repoSecret := il.SSHKeyName()
 
 	argocdApi := argocd.NewHttpClient(r.Log, env.Config.ArgocdServerUrl)
 	if err := repo.TryRegisterRepo(r.Client, r.Log, ctx, argocdApi, teamRepo, req.Namespace, repoSecret); err != nil {

--- a/controllers/util/il/il.go
+++ b/controllers/util/il/il.go
@@ -1,6 +1,10 @@
 package il
 
-import "fmt"
+import (
+	"fmt"
+
+	env "github.com/compuzest/zlifecycle-il-operator/controllers/util/env"
+)
 
 type config struct {
 	TeamDirectory          string
@@ -16,6 +20,10 @@ var Config = config{
 
 func EnvironmentComponentDirectory(teamName string, envName string) string {
 	return EnvironmentDirectory(teamName) + "/" + envName + "-environment-component"
+}
+
+func SSHKeyName() string {
+	return env.Config.CompanyName + "-ssh"
 }
 
 func RepoName(companyName string) string {


### PR DESCRIPTION
- Rename operator ssh key to be clearer
- Customer ssh key set by operator not customers

@shahadarsh @dejanzele 