### PR TITLE
fixing issue when ObjectMeta.metadata.labels has an int for app.kubernetes.io/version

### DIFF
--- a/il-operator/charts/zlifecycle-il-operator/templates/_helpers.tpl
+++ b/il-operator/charts/zlifecycle-il-operator/templates/_helpers.tpl
@@ -45,6 +45,6 @@ If release name contains chart name it will be used as a full name.
 helm.sh/charts: {{ template "core.chart" . }}
 app.kubernetes.io/name: {{ template "core.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
-app.kubernetes.io/version: {{ .Values.image.tag }}
+app.kubernetes.io/version: '{{ .Values.image.tag }}'
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}

--- a/il-operator/controller/generator.go
+++ b/il-operator/controller/generator.go
@@ -8,6 +8,7 @@ import (
 	"github.com/compuzest/zlifecycle-il-operator/controller/common/aws/awseks"
 	"github.com/compuzest/zlifecycle-il-operator/controller/common/git"
 	"github.com/compuzest/zlifecycle-il-operator/controller/common/secret"
+	"github.com/compuzest/zlifecycle-il-operator/controller/env"
 	argocd2 "github.com/compuzest/zlifecycle-il-operator/controller/services/operations/argocd"
 
 	"github.com/compuzest/zlifecycle-il-operator/controller/codegen/terraform/tfvar"
@@ -42,7 +43,7 @@ func generateAndSaveCompanyApp(fileAPI file.API, company *stablev1.Company, ilRe
 func generateAndSaveCompanyConfigWatcher(fileAPI file.API, company *stablev1.Company, ilRepoDir string) error {
 	companyConfigWatcherApp := argocd2.GenerateCompanyConfigWatcherApp(
 		company.Spec.CompanyName,
-		company.Spec.ConfigRepo.Source,
+		env.Config.GitHubRepoURL,
 		company.Spec.ConfigRepo.Path,
 	)
 


### PR DESCRIPTION
* Using Github Org Repo URL from DB in Operator for Company Watcher argocd
* fixing issue when ObjectMeta.metadata.labels has an integer for app.kubernetes.io/version

```Error: unable to build kubernetes objects from release manifest: unable to decode "": json: cannot unmarshal number into Go struct field ObjectMeta.metadata.labels of type string
```