### PR TITLE
* Quick Start not available when provisioned (refresh screen) shows up

### DIFF
--- a/web/src/components/molecules/editor/Editor.tsx
+++ b/web/src/components/molecules/editor/Editor.tsx
@@ -25,6 +25,9 @@ export const ZEditor: FC<Props> = (props: Props) => {
 				value={data}
 				options={{
 					readOnly: readOnly,
+					scrollbar: {
+						alwaysConsumeMouseWheel: false
+					},
 					...options,
 				}}
 				onChange={onChange}

--- a/web/src/components/organisms/workflow-diagram/WorkflowDiagram.tsx
+++ b/web/src/components/organisms/workflow-diagram/WorkflowDiagram.tsx
@@ -117,6 +117,9 @@ export const ZWorkflowDiagram: FC<Props> = ({ nodes, approvedBy }: Props) => {
 						return data;
 					})}
 					Component={ZEditor}
+					componentProps={{
+						readOnly: true
+					}}
 					defaultValue={'Loading info...'}
 				/>
 			);

--- a/web/src/pages/authorized/authorizedRouteNames.ts
+++ b/web/src/pages/authorized/authorizedRouteNames.ts
@@ -18,7 +18,7 @@ const ENVIRONMENT_BUILDER_URL = '/builder';
 const ENVIRONMENTS_URL = '/:projectId';
 const INFRA_URL = '/:projectId/:environmentId/infra';
 const RESOURCE_VIEW_URL = '/applications/:componentId/resource-view';
-const QUICK_START_URL = '/quick-start';
+export const QUICK_START_URL = '/quick-start';
 export const ORG_REGISTRATION = '/org-registration';
 
 const urls = [

--- a/web/src/pages/authorized/environment-components/EnvironmentComponents.tsx
+++ b/web/src/pages/authorized/environment-components/EnvironmentComponents.tsx
@@ -226,17 +226,17 @@ export const EnvironmentComponents: React.FC = () => {
 			}
 		}
 		if (configName === 'root') {
-			const rootEnv = environments.find(e => e.id === environmentId);
-			const failedEnv = ErrorStateService.getInstance().errorsInEnvironment(
-				rootEnv?.labels?.env_name || ''
-			);
+			// const rootEnv = environments.find(e => e.id === environmentId);
+			// const failedEnv = ErrorStateService.getInstance().errorsInEnvironment(
+			// 	rootEnv?.labels?.env_name || ''
+			// );
 
-			if (failedEnv?.length > 0) {
-				setEnvErrors(failedEnv);
-			}
+			// if (failedEnv?.length > 0) {
+			// 	setEnvErrors(failedEnv);
+			// }
 
-			setEnvironmentNodeSelected(true);
-			setShowSidePanel(true);
+			// setEnvironmentNodeSelected(true);
+			// setShowSidePanel(true);
 			return;
 		}
 		setEnvironmentNodeSelected(false);

--- a/web/src/pages/authorized/quick-start/guides/SetupTeamYaml.tsx
+++ b/web/src/pages/authorized/quick-start/guides/SetupTeamYaml.tsx
@@ -142,7 +142,7 @@ spec:
 							</label>
 
 							<div className="mt-10">
-								<ZEditor data={teamYaml} readOnly={true} language={'yaml'} />
+								<ZEditor height='30vh' data={teamYaml} readOnly={true} language={'yaml'} />
 							</div>
 						</section>
 					</form>

--- a/web/src/router/PrivateRoute.tsx
+++ b/web/src/router/PrivateRoute.tsx
@@ -2,6 +2,7 @@ import AuthStore from 'auth/AuthStore';
 import { cleanDagNodeCache } from 'components/organisms/tree-view/node-figure-helper';
 import { LOGIN_URL } from 'pages/anonymous/anonymousRouteNames';
 import { NotFound } from 'pages/anonymous/not-found/NotFound';
+import { QUICK_START_URL } from 'pages/authorized/authorizedRouteNames';
 import { QuickStart } from 'pages/authorized/quick-start/QuickStart';
 import { TermsAndConditions } from 'pages/authorized/terms-and-conditions/TermsAndConditons';
 import React, { ElementType, FC, ReactNode, useEffect } from 'react';
@@ -30,7 +31,7 @@ const PrivateRoute: FC<PrivateRouteProps> = ({ component: Component, ...rest }: 
 						return <NotFound />
 					}
 
-					if (user.selectedOrg && !user.selectedOrg.githubRepo) {
+					if ((user.selectedOrg && !user.selectedOrg.githubRepo) || rest.location?.pathname === QUICK_START_URL) {
 						return <QuickStart/>;
 					}
 


### PR DESCRIPTION
* Make "Provision First Environment" screen in Quick start easy to use
* Make the editor for Plan and Apply Read Only
* Make environment box not clickable until we fix audit screen