### PR TITLE
incrementing proxy_buffer_size for bff nginx to fix 502 errors when part of more than 2 orgs

### DIFF
--- a/helm-charts/bff/Chart.yaml
+++ b/helm-charts/bff/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 name: zlifecycle-web-bff
 description: A Helm chart for Kubernetes
 type: application
-version: 0.29.0
+version: 0.30.0
 appVersion: "1.16.0"

--- a/helm-charts/bff/templates/ingress.yaml
+++ b/helm-charts/bff/templates/ingress.yaml
@@ -6,6 +6,7 @@ metadata:
     nginx.ingress.kubernetes.io/backend-protocol: HTTP
     nginx.ingress.kubernetes.io/enable-cors: "true"
     nginx.ingress.kubernetes.io/cors-allow-methods: "PUT, GET, POST, OPTIONS"
+    nginx.ingress.kubernetes.io/proxy-buffer-size: 8k
 spec:
   ingressClassName: nginx
   rules:


### PR DESCRIPTION
* Tested this and its works when proxy_buffer_size is increased to 8k 

Check: https://github.com/auth0/nextjs-auth0/issues/382